### PR TITLE
Use sub packages of lodash to reduce bundle size

### DIFF
--- a/lib/utf8-binary-cutter.js
+++ b/lib/utf8-binary-cutter.js
@@ -7,7 +7,8 @@
  */
 'use strict';
 
-var _ = require('lodash');
+var transform = require('lodash.transform');
+var includes = require('lodash.includes');
 
 var DEFAULT_TRUNCATE_STRING = '...';
 var DEFAULT_TRUNCATE_STRING_BINARY_SIZE = Buffer.byteLength(DEFAULT_TRUNCATE_STRING, 'utf8');
@@ -70,10 +71,10 @@ function truncateToBinarySize(string, binaryMaxSize, truncateCallback) {
  *                   if provided, function to be called when a truncating occur.
  */
 function truncateFieldsToBinarySize(model, maxSizes, truncateCallback) {
-  return _.transform(
+  return transform(
     model,
     function (result, value, key) {
-      if(_.includes(Object.keys(maxSizes), key))  {
+      if(includes(Object.keys(maxSizes), key))  {
         var callback = function(binaryMaxSize, string, truncatedString) {
           if(truncateCallback) truncateCallback(binaryMaxSize, string, truncatedString, key);
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "utf8-binary-cutter",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -62,7 +62,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.3"
+        "samsam": "~1.1"
       }
     },
     "glob": {
@@ -71,9 +71,9 @@
       "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
       "dev": true,
       "requires": {
-        "graceful-fs": "2.0.3",
-        "inherits": "2.0.3",
-        "minimatch": "0.2.14"
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
       }
     },
     "graceful-fs": {
@@ -118,10 +118,15 @@
         }
       }
     },
-    "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.transform": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A="
     },
     "lolex": {
       "version": "1.1.0",
@@ -141,8 +146,8 @@
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "minimist": {
@@ -202,7 +207,7 @@
       "requires": {
         "formatio": "1.1.1",
         "lolex": "1.1.0",
-        "util": "0.11.0"
+        "util": ">=0.10.3 <1"
       }
     },
     "sinon-chai": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/lemonde/utf8-binary-cutter",
   "dependencies": {
-    "lodash": "^4.17.10"
+    "lodash.includes": "^4.3.0",
+    "lodash.transform": "^4.6.0"
   },
   "devDependencies": {
     "chai": "~1.10.0",


### PR DESCRIPTION
Because [98.5 % of the bundle size is lodash](https://bundlephobia.com/result?p=utf8-binary-cutter@0.9.2) whereas we use only 2 function of it.